### PR TITLE
fix incompatible 1.18

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -46,8 +46,8 @@ if ! command -v helm &> /dev/null; then
 fi
 
 HELM_VERSION=$(helm version 2>&1 | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+') || true
-if [[ ${HELM_VERSION} < "v3.0.0" ]]; then
-  echo "Please upgrade helm to v3.0.0 or higher"
+if [[ ${HELM_VERSION} < "v3.5.0" ]]; then
+  echo "Please upgrade helm to v3.5.0 or higher"
   exit 1
 fi
 


### PR DESCRIPTION
## What this PR does / why we need it:

/kind bug

When I execute the `make dev-env` command to deploy, an error is reported at line 100 of the dev-env script, prompting that the version of kubernetes 1.18 is incompatible. Through checking the relevant code of the helm github repo, we know that when the `helm template` command is executed, the mock data will be used for verification. The mock needs to specify the version of the kubernetes for compatibility. Under the version 3.5 of Helm, kubernetes 1.18 will be used for verification. 

reference：
https://github.com/helm/helm/blob/release-3.4/pkg/chartutil/capabilities.go#L34
https://github.com/helm/helm/blob/release-3.5/pkg/chartutil/capabilities.go#L32

The deployed chart must be greater than or equal to 1.19. 
reference：
https://github.com/karmada-io/multi-cluster-ingress-nginx/blob/main/charts/ingress-nginx/Chart.yaml#L19


so  i need to find a version of Helm that is compatible with 1.19. The minimum version is helm3.5

