### PR TITLE
fix golang http.server library security

### DIFF
--- a/cmd/nginx/main.go
+++ b/cmd/nginx/main.go
@@ -357,8 +357,9 @@ func registerProfiler() {
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("127.0.0.1:%v", nginx.ProfilerPort),
-		Handler: mux,
+		Addr:              fmt.Sprintf("127.0.0.1:%v", nginx.ProfilerPort),
+		ReadHeaderTimeout: 10 * time.Second,
+		Handler:           mux,
 	}
 	klog.Fatal(server.ListenAndServe())
 }

--- a/internal/ingress/controller/nginx.go
+++ b/internal/ingress/controller/nginx.go
@@ -110,9 +110,10 @@ func NewNGINXController(config *Configuration, mc metric.Collector) *NGINXContro
 
 	if n.cfg.ValidationWebhook != "" {
 		n.validationWebhookServer = &http.Server{
-			Addr:      config.ValidationWebhook,
-			Handler:   adm_controller.NewAdmissionControllerServer(&adm_controller.IngressAdmission{Checker: n}),
-			TLSConfig: ssl.NewTLSListener(n.cfg.ValidationWebhookCertPath, n.cfg.ValidationWebhookKeyPath).TLSConfig(),
+			Addr:              config.ValidationWebhook,
+			ReadHeaderTimeout: 10 * time.Second,
+			Handler:           adm_controller.NewAdmissionControllerServer(&adm_controller.IngressAdmission{Checker: n}),
+			TLSConfig:         ssl.NewTLSListener(n.cfg.ValidationWebhookCertPath, n.cfg.ValidationWebhookKeyPath).TLSConfig(),
 			// disable http/2
 			// https://github.com/kubernetes/kubernetes/issues/80313
 			// https://github.com/kubernetes/ingress-nginx/issues/6323#issuecomment-737239159


### PR DESCRIPTION
/kind cleanup

optimize http.server use, add ReadHeaderTimeout parameter，avoid to use up server resources and pass github CI verification