### PR TITLE
Fix build install messages.

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -122,6 +122,6 @@ cat <<EOF
 
 Kubernetes cluster ready and ingress-nginx listening in localhost using ports 80 and 443
 
-To delete the dev cluster execute: 'kind delete cluster --name ingress-nginx-dev'
+To delete the dev cluster execute: 'kind delete cluster --name ${KIND_CLUSTER_NAME}'
 
 EOF


### PR DESCRIPTION
/kind cleanup

## What this PR does / why we need it:
```--name ingress-nginx-dev``` can not be fasten.
Because it is can be replaced by ```env KIND_CLUSTER_NAME```