### PR TITLE
fix: install ingress-nginx by dev-env.sh script

### DIFF
--- a/build/dev-env.sh
+++ b/build/dev-env.sh
@@ -100,7 +100,8 @@ kubectl create namespace ingress-nginx &> /dev/null || true
 cat << EOF | helm template ingress-nginx ${DIR}/../charts/ingress-nginx --namespace=ingress-nginx --values - | kubectl apply -n ingress-nginx --validate=false -f -
 controller:
   image:
-    repository: ${REGISTRY}/controller
+    registry: gcr.io
+    image: ${REGISTRY}/controller
     tag: ${TAG}
     digest:
   config:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above --->
<!--- Please don't @-mention people in PR or commit messages (do so in an additional comment). --->

I install the ingress-controller in the kubernetes, the context of the script is from dev-env.sh 

install.sh
```
kubectl create ns ingress-nginx

cat << EOF | helm template ingress-nginx ./src/charts/ingress-nginx --namespace=ingress-nginx --values - | kubectl apply -n ingress-nginx --validate=false -f -
controller:
  image:
    repository: registry-dev.indc.vnet.com
    image: system_containers/k8s-staging-ingress-nginx
    tag: v1.1.1
    digest:
  config:
    worker-processes: "1"
  podLabels:
    deploy-date: "$(date +%s)"
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
  hostPort:
    enabled: true
  terminationGracePeriodSeconds: 0
  service:
    type: NodePort
  admissionWebhooks:
    patch:
      image:
        registry: registry-dev.indc.vnet.com
        image: system_containers/kube-webhook-certgen
        tag: v1.1.1
        digest: sha256:78351fc9d9b5f835e0809921c029208faeb7fbb6dc2d3b0d1db0a6584195cfed
EOF
```

I got the error
```
NAME                                        READY   STATUS             RESTARTS   AGE   IP               NODE         NOMINATED NODE   READINESS GATES
ingress-nginx-admission-create-tmtk7        0/1     Completed          0          11m   172.31.175.202   k8s-node-6   <none>           <none>
ingress-nginx-admission-patch-s9rfh         0/1     Completed          0          11m   172.31.175.222   k8s-node-6   <none>           <none>
ingress-nginx-controller-75b989ddd7-2j949   0/1     ImagePullBackOff   0          11m   172.31.55.171    k8s-node-4   <none>           <none>
```

I check the log of ingress-nginx-controller-75b989ddd7-2j949  pod, the result is 

```
  containerStatuses:
  - image: registry-dev.indc.vnet.com:v1.1.1
    imageID: ""
    lastState: {}
    name: controller
    ready: false
    restartCount: 0
    started: false
    state:
      waiting:
        message: Back-off pulling image "registry-dev.indc.vnet.com:v1.1.1"
        reason: ImagePullBackOff
```

so I think the dev-env.sh has problem

## What this PR does / why we need it:
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation only

## Which issue/s this PR fixes
<!--
(optional, in `fixes #<issue number>` format, will close that issue when PR gets merged):

fixes #
-->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/kubernetes/ingress-nginx/blob/main/CONTRIBUTING.md) guide
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
